### PR TITLE
redux basic implementation

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2484,6 +2484,15 @@
         "@types/node": "*"
       }
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -2655,6 +2664,11 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
       "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
+    },
+    "@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "@types/ws": {
       "version": "8.5.3",
@@ -5794,6 +5808,21 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
     },
     "hoopy": {
       "version": "0.1.4",
@@ -9542,6 +9571,26 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "react-redux": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.2.tgz",
+      "integrity": "sha512-nBwiscMw3NoP59NFCXFf02f8xdo+vSHT/uZ1ldDwF7XaTpzm+Phk97VT4urYBl5TYAPNVaFm12UHAEyzkpNzRA==",
+      "requires": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.1.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
+          "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg=="
+        }
+      }
+    },
     "react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -9646,6 +9695,19 @@
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
       }
+    },
+    "redux": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "redux-thunk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q=="
     },
     "regenerate": {
       "version": "1.4.2",
@@ -10857,6 +10919,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "use-sync-external-store": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz",
+      "integrity": "sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,10 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
-    "react-scripts": "5.0.1"
+    "react-redux": "^8.0.2",
+    "react-scripts": "5.0.1",
+    "redux": "^4.2.0",
+    "redux-thunk": "^2.4.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,0 +1,4 @@
+body {
+    display: flex;
+    justify-content: center;
+}

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,7 +1,0 @@
-import "./App.css"
-
-function App() {
-    return <div className="App">Food Fast</div>
-}
-
-export default App

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,0 +1,22 @@
+import { useDispatch, useSelector } from "react-redux"
+import "./App.css"
+import ReduxTest from "./components/ReduxTest/ReduxTest"
+import { runMainTest } from "./redux/actions/sync"
+
+function App() {
+    const dispatch = useDispatch()
+    const state = useSelector((state) => state.main)
+
+    return (
+        <div className="App">
+            main Test = {state.mainTest}
+            <button onClick={() => dispatch(runMainTest())}>
+                Run Main Test
+            </button>
+            <h1>Food Fast</h1>
+            <ReduxTest />
+        </div>
+    )
+}
+
+export default App

--- a/client/src/components/ReduxTest/ReduxTest.jsx
+++ b/client/src/components/ReduxTest/ReduxTest.jsx
@@ -1,0 +1,53 @@
+import React from "react"
+import { useDispatch, useSelector } from "react-redux"
+import { runAsyncTest } from "../../redux/actions/async"
+import { resetTests, runSyncTest } from "../../redux/actions/sync"
+
+const ReduxTest = () => {
+    const dispatch = useDispatch()
+    const state = useSelector((state) => state.tests)
+
+    return (
+        <div
+            style={{
+                padding: "1rem",
+                backgroundColor: "lightgrey"
+            }}
+        >
+            <table>
+                <thead>
+                    <tr>
+                        <th>Redux Test</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>sync =</td>
+                        <td>{state.syncTest}</td>
+                    </tr>
+                    <tr>
+                        <td>async =</td>
+                        <td>{state.asyncTest}</td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <button
+                onClick={() => {
+                    dispatch(runSyncTest("waiting"))
+                    dispatch(runSyncTest("success"))
+                }}
+            >
+                Run Sync Test
+            </button>
+
+            <button onClick={() => dispatch(runAsyncTest())}>
+                Run Async Test
+            </button>
+
+            <button onClick={() => dispatch(resetTests())}>Reset</button>
+        </div>
+    )
+}
+
+export default ReduxTest

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,11 +1,16 @@
 import React from "react"
 import ReactDOM from "react-dom/client"
+import { Provider } from "react-redux"
+import { store } from "./redux/store"
+
 import "./index.css"
 import App from "./App"
 
 const root = ReactDOM.createRoot(document.getElementById("root"))
 root.render(
     <React.StrictMode>
-        <App />
+        <Provider store={store}>
+            <App />
+        </Provider>
     </React.StrictMode>
 )

--- a/client/src/redux/actions/async.js
+++ b/client/src/redux/actions/async.js
@@ -1,0 +1,9 @@
+import { ASYNC_TEST_1 } from "./types"
+
+export const runAsyncTest = () => (dispatch) => {
+    dispatch({ type: ASYNC_TEST_1, payload: "waiting" })
+
+    setTimeout(() => {
+        dispatch({ type: ASYNC_TEST_1, payload: "success" })
+    }, 5000)
+}

--- a/client/src/redux/actions/sync.js
+++ b/client/src/redux/actions/sync.js
@@ -1,0 +1,7 @@
+import { SYNC_TEST_1, RESET_TESTS, MAIN_TEST } from "./types"
+
+export const runSyncTest = (str) => ({ type: SYNC_TEST_1, payload: str })
+
+export const resetTests = () => ({ type: RESET_TESTS })
+
+export const runMainTest = () => ({ type: MAIN_TEST })

--- a/client/src/redux/actions/types.js
+++ b/client/src/redux/actions/types.js
@@ -1,4 +1,4 @@
-export const MAIN_TEST = "main_test"
-export const ASYNC_TEST_1 = "async_action_1"
-export const SYNC_TEST_1 = "sync_action_1"
 export const RESET_TESTS = "reset_tests"
+export const MAIN_TEST = "main_test"
+export const ASYNC_TEST_1 = "async_test_1"
+export const SYNC_TEST_1 = "sync_test_1"

--- a/client/src/redux/actions/types.js
+++ b/client/src/redux/actions/types.js
@@ -1,0 +1,4 @@
+export const MAIN_TEST = "main_test"
+export const ASYNC_TEST_1 = "async_action_1"
+export const SYNC_TEST_1 = "sync_action_1"
+export const RESET_TESTS = "reset_tests"

--- a/client/src/redux/reducers/index.js
+++ b/client/src/redux/reducers/index.js
@@ -1,0 +1,9 @@
+import { combineReducers } from "redux"
+
+import main from "./main"
+import tests from "./tests"
+
+export default combineReducers({
+    main,
+    tests
+})

--- a/client/src/redux/reducers/main.js
+++ b/client/src/redux/reducers/main.js
@@ -1,0 +1,24 @@
+import { MAIN_TEST, RESET_TESTS } from "../actions/types"
+
+const initialState = { mainTest: "default" }
+
+const main = (state = initialState, action) => {
+    let newState = { ...state }
+
+    switch (action.type) {
+        default:
+            break
+
+        case MAIN_TEST:
+            newState.mainTest = "success"
+            break
+
+        case RESET_TESTS:
+            newState.mainTest = "default"
+            break
+    }
+
+    return { ...newState }
+}
+
+export default main

--- a/client/src/redux/reducers/tests.js
+++ b/client/src/redux/reducers/tests.js
@@ -1,0 +1,31 @@
+import { ASYNC_TEST_1, RESET_TESTS, SYNC_TEST_1 } from "../actions/types"
+
+const initialState = {
+    syncTest: "default",
+    asyncTest: "default"
+}
+
+const tests = (state = initialState, action) => {
+    let newState = { ...state }
+
+    switch (action.type) {
+        default:
+            break
+
+        case SYNC_TEST_1:
+            newState.syncTest = action.payload
+            break
+
+        case ASYNC_TEST_1:
+            newState.asyncTest = action.payload
+            break
+
+        case RESET_TESTS:
+            newState = initialState
+            break
+    }
+
+    return { ...newState }
+}
+
+export default tests

--- a/client/src/redux/store.js
+++ b/client/src/redux/store.js
@@ -1,0 +1,9 @@
+import { applyMiddleware, createStore, compose } from "redux"
+import thunk from "redux-thunk"
+import reducer from "./reducers/index"
+
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
+export const store = createStore(
+    reducer,
+    composeEnhancers(applyMiddleware(thunk))
+)


### PR DESCRIPTION
Necesitan hacer `npm install` en la carpeta del cliente para que les instale `redux`, `react-redux` y `redux-thunk`.

Implementar logica de negocio en `redux/reducers/main.js`.
Si necesitan guardar datos en redux que no interactuan con `main.js`, creen otro reducer (por ej: `tests.js`), y agreguenlo a `reducers/index.js`